### PR TITLE
Use full-path for serialize trait method to avoid collisions with other serialize trait methods

### DIFF
--- a/serde-lite-derive/src/serialize.rs
+++ b/serde-lite-derive/src/serialize.rs
@@ -362,7 +362,7 @@ fn serialize_unnamed_fields_1() -> (TokenStream, TokenStream) {
     });
 
     serialize.extend(quote! {
-        let __val = #name.serialize()?;
+        let __val = serde_lite::Serialize::serialize(#name)?;
     });
 
     (deconstructor, serialize)
@@ -393,7 +393,7 @@ fn serialize_unnamed_fields_n(fields: &FieldsUnnamed) -> (TokenStream, TokenStre
         });
 
         serialize.extend(quote! {
-            match #name.serialize() {
+            match serde_lite::Serialize::serialize(#name) {
                 Ok(v) => __arr.push(v),
                 Err(err) => __field_errors.push(serde_lite::UnnamedFieldError::new(#lindex, err)),
             }


### PR DESCRIPTION
I had this issue recently where trying to implement Serialize and Deserialize from both Serde and Serde-lite gave me this error:
```rust
error[E0034]: multiple applicable items in scope
   --> shared/src/api_models/validation.rs:21:5
    |
21  |     serde_lite::Serialize,
    |     ^^^^^^^^^^^^^^^^^^^^^ multiple `serialize` found
    |
note: candidate #1 is defined in the trait `auth::_::_serde::Serialize`
   --> /home/inno/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.215/src/ser/mod.rs:256:5
    |
256 | /     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
257 | |     where
258 | |         S: Serializer;
    | |______________________^
note: candidate #2 is defined in the trait `serde_lite::Serialize`
   --> /home/inno/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-lite-0.5.0/src/serialize.rs:18:5
    |
18  |     fn serialize(&self) -> Result<Intermediate, Error>;
```

This PR resolves this issue by using the full-path to call serialize.
