### PR TITLE
Better handling of Hashmaps

### DIFF
--- a/serde-lite/src/deserialize.rs
+++ b/serde-lite/src/deserialize.rs
@@ -270,11 +270,12 @@ deserialize_tuple!(14 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T
 deserialize_tuple!(15 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14));
 deserialize_tuple!(16 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14 15 T15));
 
-impl<K, V> Deserialize for HashMap<K, V>
+impl<K, V, S> Deserialize for HashMap<K, V, S>
 where
     K: TryFrom<Cow<'static, str>> + Eq + Hash,
     <K as TryFrom<Cow<'static, str>>>::Error: std::fmt::Display,
     V: Deserialize,
+    S: core::hash::BuildHasher + Default,
 {
     fn deserialize(val: &Intermediate) -> Result<Self, Error>
     where
@@ -284,7 +285,7 @@ where
             .as_map()
             .ok_or_else(|| Error::invalid_value_static("map"))?;
 
-        let mut res = HashMap::with_capacity(val.len());
+        let mut res = HashMap::with_capacity_and_hasher(val.len(), S::default());
 
         for (name, value) in val {
             let k = K::try_from(name.clone()).map_err(Error::invalid_value)?;
@@ -298,11 +299,12 @@ where
 }
 
 #[cfg(feature = "preserve-order")]
-impl<K, V> Deserialize for indexmap::IndexMap<K, V>
+impl<K, V, S> Deserialize for indexmap::IndexMap<K, V, S>
 where
     K: TryFrom<Cow<'static, str>> + Eq + Hash,
     <K as TryFrom<Cow<'static, str>>>::Error: std::fmt::Display,
     V: Deserialize,
+    S: core::hash::BuildHasher + Default,
 {
     fn deserialize(val: &Intermediate) -> Result<Self, Error>
     where
@@ -312,7 +314,7 @@ where
             .as_map()
             .ok_or_else(|| Error::invalid_value_static("map"))?;
 
-        let mut res = indexmap::IndexMap::with_capacity(val.len());
+        let mut res = indexmap::IndexMap::with_capacity_and_hasher(val.len(), S::default());
 
         for (name, value) in val {
             let k = K::try_from(name.clone()).map_err(Error::invalid_value)?;

--- a/serde-lite/src/deserialize.rs
+++ b/serde-lite/src/deserialize.rs
@@ -327,7 +327,7 @@ macro_rules! deserialize_wrapper {
     ( $x:ident ) => {
         impl<T> Deserialize for $x<T>
         where
-            T: Deserialize,
+            T: Deserialize + Sized,
         {
             #[inline]
             fn deserialize(val: &Intermediate) -> Result<Self, Error> {
@@ -345,3 +345,23 @@ deserialize_wrapper!(Arc);
 deserialize_wrapper!(Cell);
 deserialize_wrapper!(RefCell);
 deserialize_wrapper!(Mutex);
+
+macro_rules! deserialize_wrapped_array {
+    ( $x:ident ) => {
+        impl<T> Deserialize for $x<[T]>
+        where
+            T: Deserialize,
+            Vec<T>: Into<$x<[T]>>,
+        {
+            #[inline]
+            fn deserialize(val: &Intermediate) -> Result<Self, Error> {
+                let inner = Vec::<T>::deserialize(val)?;
+                Ok(inner.into())
+            }
+        }
+    };
+}
+
+deserialize_wrapped_array!(Box);
+deserialize_wrapped_array!(Rc);
+deserialize_wrapped_array!(Arc);

--- a/serde-lite/src/deserialize.rs
+++ b/serde-lite/src/deserialize.rs
@@ -270,10 +270,11 @@ deserialize_tuple!(14 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T
 deserialize_tuple!(15 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14));
 deserialize_tuple!(16 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14 15 T15));
 
-impl<K, V> Deserialize for HashMap<K, V>
+impl<K, V, S> Deserialize for HashMap<K, V, S>
 where
     K: From<Cow<'static, str>> + Eq + Hash,
     V: Deserialize,
+    S: core::hash::BuildHasher + Default,
 {
     fn deserialize(val: &Intermediate) -> Result<Self, Error>
     where
@@ -283,7 +284,7 @@ where
             .as_map()
             .ok_or_else(|| Error::invalid_value_static("map"))?;
 
-        let mut res = HashMap::with_capacity(val.len());
+        let mut res = HashMap::with_capacity_and_hasher(val.len(), S::default());
 
         for (name, value) in val {
             let k = K::from(name.clone());
@@ -297,10 +298,11 @@ where
 }
 
 #[cfg(feature = "preserve-order")]
-impl<K, V> Deserialize for indexmap::IndexMap<K, V>
+impl<K, V, S> Deserialize for indexmap::IndexMap<K, V, S>
 where
     K: From<Cow<'static, str>> + Eq + Hash,
     V: Deserialize,
+    S: core::hash::BuildHasher + Default,
 {
     fn deserialize(val: &Intermediate) -> Result<Self, Error>
     where
@@ -310,7 +312,7 @@ where
             .as_map()
             .ok_or_else(|| Error::invalid_value_static("map"))?;
 
-        let mut res = indexmap::IndexMap::with_capacity(val.len());
+        let mut res = indexmap::IndexMap::with_capacity_and_hasher(val.len(), S::default());
 
         for (name, value) in val {
             let k = K::from(name.clone());

--- a/serde-lite/src/deserialize.rs
+++ b/serde-lite/src/deserialize.rs
@@ -272,7 +272,8 @@ deserialize_tuple!(16 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T
 
 impl<K, V, S> Deserialize for HashMap<K, V, S>
 where
-    K: From<Cow<'static, str>> + Eq + Hash,
+    K: TryFrom<Cow<'static, str>> + Eq + Hash,
+    <K as TryFrom<Cow<'static, str>>>::Error: std::fmt::Display,
     V: Deserialize,
     S: core::hash::BuildHasher + Default,
 {
@@ -287,7 +288,7 @@ where
         let mut res = HashMap::with_capacity_and_hasher(val.len(), S::default());
 
         for (name, value) in val {
-            let k = K::from(name.clone());
+            let k = K::try_from(name.clone()).map_err(Error::invalid_value)?;
             let v = V::deserialize(value)?;
 
             res.insert(k, v);
@@ -300,7 +301,8 @@ where
 #[cfg(feature = "preserve-order")]
 impl<K, V, S> Deserialize for indexmap::IndexMap<K, V, S>
 where
-    K: From<Cow<'static, str>> + Eq + Hash,
+    K: TryFrom<Cow<'static, str>> + Eq + Hash,
+    <K as TryFrom<Cow<'static, str>>>::Error: std::fmt::Display,
     V: Deserialize,
     S: core::hash::BuildHasher + Default,
 {
@@ -315,7 +317,7 @@ where
         let mut res = indexmap::IndexMap::with_capacity_and_hasher(val.len(), S::default());
 
         for (name, value) in val {
-            let k = K::from(name.clone());
+            let k = K::try_from(name.clone()).map_err(Error::invalid_value)?;
             let v = V::deserialize(value)?;
 
             res.insert(k, v);

--- a/serde-lite/src/deserialize.rs
+++ b/serde-lite/src/deserialize.rs
@@ -359,6 +359,13 @@ macro_rules! deserialize_wrapped_array {
                 Ok(inner.into())
             }
         }
+        impl Deserialize for $x<str> {
+            #[inline]
+            fn deserialize(val: &Intermediate) -> Result<Self, Error> {
+                let inner = String::deserialize(val)?;
+                Ok(inner.into())
+            }
+        }
     };
 }
 

--- a/serde-lite/src/deserialize.rs
+++ b/serde-lite/src/deserialize.rs
@@ -270,11 +270,10 @@ deserialize_tuple!(14 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T
 deserialize_tuple!(15 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14));
 deserialize_tuple!(16 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14 15 T15));
 
-impl<K, V, S> Deserialize for HashMap<K, V, S>
+impl<K, V> Deserialize for HashMap<K, V>
 where
     K: From<Cow<'static, str>> + Eq + Hash,
     V: Deserialize,
-    S: core::hash::BuildHasher + Default,
 {
     fn deserialize(val: &Intermediate) -> Result<Self, Error>
     where
@@ -284,7 +283,7 @@ where
             .as_map()
             .ok_or_else(|| Error::invalid_value_static("map"))?;
 
-        let mut res = HashMap::with_capacity_and_hasher(val.len(), S::default());
+        let mut res = HashMap::with_capacity(val.len());
 
         for (name, value) in val {
             let k = K::from(name.clone());
@@ -298,11 +297,10 @@ where
 }
 
 #[cfg(feature = "preserve-order")]
-impl<K, V, S> Deserialize for indexmap::IndexMap<K, V, S>
+impl<K, V> Deserialize for indexmap::IndexMap<K, V>
 where
     K: From<Cow<'static, str>> + Eq + Hash,
     V: Deserialize,
-    S: core::hash::BuildHasher + Default,
 {
     fn deserialize(val: &Intermediate) -> Result<Self, Error>
     where
@@ -312,7 +310,7 @@ where
             .as_map()
             .ok_or_else(|| Error::invalid_value_static("map"))?;
 
-        let mut res = indexmap::IndexMap::with_capacity_and_hasher(val.len(), S::default());
+        let mut res = indexmap::IndexMap::with_capacity(val.len());
 
         for (name, value) in val {
             let k = K::from(name.clone());

--- a/serde-lite/src/serialize.rs
+++ b/serde-lite/src/serialize.rs
@@ -354,6 +354,12 @@ macro_rules! serialize_wrapper {
                 <&[T] as Serialize>::serialize(&&**self)
             }
         }
+        impl Serialize for $x<str> {
+            #[inline]
+            fn serialize(&self) -> Result<Intermediate, Error> {
+                <&str as Serialize>::serialize(&&**self)
+            }
+        }
     };
 }
 

--- a/serde-lite/src/serialize.rs
+++ b/serde-lite/src/serialize.rs
@@ -281,11 +281,10 @@ serialize_tuple!(14 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10
 serialize_tuple!(15 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14));
 serialize_tuple!(16 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14 15 T15));
 
-impl<K, V, S> Serialize for HashMap<K, V, S>
+impl<K, V> Serialize for HashMap<K, V>
 where
     K: ToString,
     V: Serialize,
-    S: core::hash::BuildHasher,
 {
     fn serialize(&self) -> Result<Intermediate, Error> {
         let mut res = Map::with_capacity(self.len());
@@ -299,11 +298,10 @@ where
 }
 
 #[cfg(feature = "preserve-order")]
-impl<K, V, S> Serialize for indexmap::IndexMap<K, V, S>
+impl<K, V> Serialize for indexmap::IndexMap<K, V>
 where
     K: ToString,
     V: Serialize,
-    S: core::hash::BuildHasher,
 {
     fn serialize(&self) -> Result<Intermediate, Error> {
         let mut res = Map::with_capacity(self.len());

--- a/serde-lite/src/serialize.rs
+++ b/serde-lite/src/serialize.rs
@@ -281,10 +281,11 @@ serialize_tuple!(14 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10
 serialize_tuple!(15 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14));
 serialize_tuple!(16 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14 15 T15));
 
-impl<K, V> Serialize for HashMap<K, V>
+impl<K, V, S> Serialize for HashMap<K, V, S>
 where
     K: ToString,
     V: Serialize,
+    S: core::hash::BuildHasher,
 {
     fn serialize(&self) -> Result<Intermediate, Error> {
         let mut res = Map::with_capacity(self.len());
@@ -298,10 +299,11 @@ where
 }
 
 #[cfg(feature = "preserve-order")]
-impl<K, V> Serialize for indexmap::IndexMap<K, V>
+impl<K, V, S> Serialize for indexmap::IndexMap<K, V, S>
 where
     K: ToString,
     V: Serialize,
+    S: core::hash::BuildHasher,
 {
     fn serialize(&self) -> Result<Intermediate, Error> {
         let mut res = Map::with_capacity(self.len());

--- a/serde-lite/src/serialize.rs
+++ b/serde-lite/src/serialize.rs
@@ -345,6 +345,15 @@ macro_rules! serialize_wrapper {
                 <T as Serialize>::serialize(&*self)
             }
         }
+        impl<T> Serialize for $x<[T]>
+        where
+            T: Serialize,
+        {
+            #[inline]
+            fn serialize(&self) -> Result<Intermediate, Error> {
+                <&[T] as Serialize>::serialize(&&**self)
+            }
+        }
     };
 }
 

--- a/serde-lite/tests/derive.rs
+++ b/serde-lite/tests/derive.rs
@@ -1,6 +1,7 @@
 use std::convert::TryInto;
 
 use serde_lite::{intermediate, Deserialize, Error, Intermediate, Map, Number, Serialize, Update};
+use serde_lite_derive::{Deserialize, Serialize, Update};
 
 #[test]
 fn test_struct_deserialize() {

--- a/serde-lite/tests/derive.rs
+++ b/serde-lite/tests/derive.rs
@@ -2,8 +2,6 @@ use std::convert::TryInto;
 
 use serde_lite::{intermediate, Deserialize, Error, Intermediate, Map, Number, Serialize, Update};
 
-use serde_lite_derive::{Deserialize, Serialize, Update};
-
 #[test]
 fn test_struct_deserialize() {
     let input = intermediate!({
@@ -145,6 +143,26 @@ fn test_empty_struct_deserialize() {
     assert!(UnitStruct::deserialize(&Intermediate::None).is_ok());
     assert!(EmptyStruct::deserialize(&Intermediate::None).is_ok());
     assert!(EmptyTupleStruct::deserialize(&Intermediate::None).is_ok());
+}
+
+#[test]
+fn boxed_slices_deserialize() {
+    #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+    struct Slices {
+        boxed: Box<[u8]>,
+        rced: std::rc::Rc<[u8]>,
+        arced: std::sync::Arc<[u8]>,
+    }
+
+    let slices = Slices {
+        boxed: vec![0, 1, 2, 3, 4].into_boxed_slice(),
+        rced: vec![0, 1, 2, 3, 4].into(),
+        arced: vec![0, 1, 2, 3, 4].into(),
+    };
+    assert_eq!(
+        slices,
+        Slices::deserialize(&slices.serialize().expect("serializes")).expect("deserializes")
+    )
 }
 
 #[test]


### PR DESCRIPTION
(builds on my other pull request for Box/Rc/Arc, but can be easily disentangled).

The blanket implementation for HashMaps has two too-narrow properties that can be generalized easily, as done by this pull requests:
- it disregarded the Hasher implementation in the generics for HashMap, i.e. it used `HashMap<K,V>` instead of `HashMap<K,V,S>`, which doesn't allow for using popular hashing crates such as fxhash and rustc_hash,
- it required that the keys implement `From<Cow<'static, str>>` - this PR generalizes this to `TryFrom` to allow for possibly *fallible* parsing of HashMap keys. 

The latter could be changed to requiring `serde_lite::Deserialize` instead, with the implicit contract that the `Intermediate` used has to be a string, but that would a breaking change, whereas everything else in this PR should be backwards compatible.